### PR TITLE
Add dark theme toggle with CSS variables

### DIFF
--- a/budgetier.html
+++ b/budgetier.html
@@ -9,9 +9,10 @@
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two|Solway&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <script src="js/theme-toggle.js"></script>
     <style>
     </style>
-    <body class="w3-light-grey">
+    <body>
         <div class="w3-content w3-margin-top" style="max-width:1400px;">
             <div class="w3-row-padding">       
                 <div class="w3-bar w3-card w3-blue-grey w3-margin-bottom">
@@ -20,6 +21,7 @@
                     <a href="slacker.html" class="w3-bar-item w3-hover-light-grey w3-button">Slacker</a>
                     <a href="budgetier.html" class="w3-bar-item w3-hover-light-grey w3-button">Budgetier</a>
                     <!--<a href="#" class="w3-bar-item w3-hover-light-grey w3-button">Blog</a> -->
+                    <button id="theme-toggle" class="w3-bar-item w3-hover-light-grey w3-button w3-right">Toggle Theme</button>
                 </div>
             </div>
         </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,3 +1,19 @@
+/* Theme variables */
+:root {
+    --bg-color: #f1f1f1;
+    --text-color: #000000;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+body.dark-theme {
+    --bg-color: #121212;
+    --text-color: #f1f1f1;
+}
+
 html,body,h1,h3,h4,h5,h6,td {
     font-family: 'Solway', serif !important;
 }

--- a/index.html
+++ b/index.html
@@ -7,9 +7,10 @@
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two|Solway&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <script src="js/theme-toggle.js"></script>
     <style>
     </style>
-    <body class="w3-light-grey">
+    <body>
         <div class="w3-content w3-margin-top" style="max-width:1400px;">
             <div class="w3-bar w3-card w3-blue-grey w3-margin-bottom">
                 <a href="index.html" class="w3-bar-item w3-hover-light-grey w3-button">Home</a>
@@ -17,6 +18,7 @@
                 <a href="slacker.html" class="w3-bar-item w3-hover-light-grey w3-button">Slacker</a>
                 <a href="budgetier.html" class="w3-bar-item w3-hover-light-grey w3-button">Budgetier</a>
                 <!--<a href="#" class="w3-bar-item w3-hover-light-grey w3-button">Blog</a> -->
+                <button id="theme-toggle" class="w3-bar-item w3-hover-light-grey w3-button w3-right">Toggle Theme</button>
             </div>
             <div class="flex-container">
                 <div class="flex-containter-vert">

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const storedTheme = localStorage.getItem('theme');
+  if (storedTheme === 'dark') {
+    document.body.classList.add('dark-theme');
+  }
+
+  const toggle = document.getElementById('theme-toggle');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark-theme');
+      const theme = document.body.classList.contains('dark-theme') ? 'dark' : 'light';
+      localStorage.setItem('theme', theme);
+    });
+  }
+});

--- a/resume.html
+++ b/resume.html
@@ -7,9 +7,10 @@
 <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
 <link href="https://fonts.googleapis.com/css?family=Lobster+Two|Solway&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<script src="js/theme-toggle.js"></script>
 <style>
 </style>
-<body class="w3-light-grey">
+<body>
 
 <!-- Page Container -->
 <div class="w3-content w3-margin-top" style="max-width:1400px;">
@@ -17,13 +18,14 @@
   <!-- The Grid -->
   <div class="w3-row-padding">
   
-    <div class="w3-bar w3-card w3-blue-grey w3-margin-bottom">
-      <a href="index.html" class="w3-bar-item w3-hover-light-grey w3-button">Home</a>
-      <a href="resume.html" class="w3-bar-item w3-hover-light-grey w3-button">Resume</a>
-      <a href="slacker.html" class="w3-bar-item w3-hover-light-grey w3-button">Slacker</a>
-      <a href="budgetier.html" class="w3-bar-item w3-hover-light-grey w3-button">Budgetier</a>
-      <!--<a href="#" class="w3-bar-item w3-hover-light-grey w3-button">Blog</a> -->
-    </div>
+      <div class="w3-bar w3-card w3-blue-grey w3-margin-bottom">
+        <a href="index.html" class="w3-bar-item w3-hover-light-grey w3-button">Home</a>
+        <a href="resume.html" class="w3-bar-item w3-hover-light-grey w3-button">Resume</a>
+        <a href="slacker.html" class="w3-bar-item w3-hover-light-grey w3-button">Slacker</a>
+        <a href="budgetier.html" class="w3-bar-item w3-hover-light-grey w3-button">Budgetier</a>
+        <!--<a href="#" class="w3-bar-item w3-hover-light-grey w3-button">Blog</a> -->
+        <button id="theme-toggle" class="w3-bar-item w3-hover-light-grey w3-button w3-right">Toggle Theme</button>
+      </div>
 
     <!-- Left Column -->
     <div class="w3-third">

--- a/slacker.html
+++ b/slacker.html
@@ -7,17 +7,19 @@
         <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
         <link href="https://fonts.googleapis.com/css?family=Lobster+Two|Solway&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+        <script src="js/theme-toggle.js"></script>
     </head>
     <body>
         <div class="w3-content w3-margin-top" style="max-width:1400px;">
 
-            <div class="w3-bar w3-card w3-blue-grey w3-margin-bottom">
-                <a href="index.html" class="w3-bar-item w3-hover-light-grey w3-button">Home</a>
-                <a href="resume.html" class="w3-bar-item w3-hover-light-grey w3-button">Resume</a>
-                <a href="slacker.html" class="w3-bar-item w3-hover-light-grey w3-button">Slacker</a>
-                <a href="budgetier.html" class="w3-bar-item w3-hover-light-grey w3-button">Budgetier</a>
-                <!--<a href="#" class="w3-bar-item w3-hover-light-grey w3-button">Blog</a> -->
-            </div>
+              <div class="w3-bar w3-card w3-blue-grey w3-margin-bottom">
+                  <a href="index.html" class="w3-bar-item w3-hover-light-grey w3-button">Home</a>
+                  <a href="resume.html" class="w3-bar-item w3-hover-light-grey w3-button">Resume</a>
+                  <a href="slacker.html" class="w3-bar-item w3-hover-light-grey w3-button">Slacker</a>
+                  <a href="budgetier.html" class="w3-bar-item w3-hover-light-grey w3-button">Budgetier</a>
+                  <!--<a href="#" class="w3-bar-item w3-hover-light-grey w3-button">Blog</a> -->
+                  <button id="theme-toggle" class="w3-bar-item w3-hover-light-grey w3-button w3-right">Toggle Theme</button>
+              </div>
 
             <div class="slacker-container">
                 <form>
@@ -38,7 +40,7 @@
                 </div>
             </div>
 
-        </div>
-    </body class="w3-light-grey">
+      </div>
+  </body>
 </html>
 


### PR DESCRIPTION
## Summary
- define CSS custom properties for page background and text colors
- create a `.dark-theme` override and script to toggle it with localStorage persistence
- add toggle button and theme script to all HTML pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899677e357883318b2d1f3ebfba8280