### PR TITLE
Add Leaflet map to visualize state moves

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -14,3 +14,16 @@ h2 {
     display: flex;
     flex-direction: column;
 }
+
+#map {
+    width: 100%;
+    height: 400px;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+@media (max-width: 600px) {
+    #map {
+        height: 300px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two|Solway&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-sA+e2I3b80qGpQ4P+PxUFjeY6tY9vW0ck1A2S/bjMyM="
+      crossorigin=""
+    />
     <style>
     </style>
     <body class="w3-light-grey">
@@ -24,7 +30,8 @@
                         <h1>Hi, I'm Claire.</h1>
         
                         <p>FL > VA > CT > CA > ID > CT > NM > ID > NM > OK > TX</p>
-        
+                        <div id="map"></div>
+
                         <h2>New here?</h2>
                         <p>By day, I'm an Engineering Manager at Larson Texts. By night, I'm addicted to building silly tools and playing video games. Sometimes I stream these events on Twitch.</p>
                     </div>
@@ -39,5 +46,12 @@
         <a href="https://github.com/justaskclaire/justaskclaire.com" target="_blank"><i class="fa fa-github fa-3x w3-hover-opacity w3-margin"></i></a>
         <!-- <a href="https://www.twitch.tv/justaskclaire" target="_blank"><i class="fa fa-twitch fa-3x w3-hover-opacity w3-margin"></i></a> -->
         </footer>
+        <script
+          src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+          integrity="sha256-o9N1j4k74tkkcLZeBQeaKKADjLr3Lr2P72U6DGcVCjo="
+          crossorigin=""
+        ></script>
+        <script src="js/map.js"></script>
     </body>
 </html>
+

--- a/js/map.js
+++ b/js/map.js
@@ -1,0 +1,24 @@
+const stateSequence = ["FL", "VA", "CT", "CA", "ID", "CT", "NM", "ID", "NM", "OK", "TX"];
+
+const stateCoords = {
+  FL: [27.6648, -81.5158],
+  VA: [37.4316, -78.6569],
+  CT: [41.6032, -73.0877],
+  CA: [36.7783, -119.4179],
+  ID: [44.0682, -114.7420],
+  NM: [34.5199, -105.8701],
+  OK: [35.4676, -97.5164],
+  TX: [31.9686, -99.9018]
+};
+
+const map = L.map('map').setView([39.8283, -98.5795], 4);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+stateSequence.forEach((state, idx) => {
+  const coords = stateCoords[state];
+  if (coords) {
+    L.marker(coords).addTo(map).bindPopup(`${idx + 1}. ${state}`);
+  }
+});


### PR DESCRIPTION
## Summary
- Embed Leaflet via CDN and add map container on homepage
- Populate map markers from state sequence to show moving history
- Style map container for responsive display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6899678a75f08331a019975b1d220e5a)